### PR TITLE
Create filenames in ascending sort order

### DIFF
--- a/mr/hermes/__init__.py
+++ b/mr/hermes/__init__.py
@@ -26,7 +26,7 @@ class DebuggingServer(smtpd.DebuggingServer):
             while os.path.exists(dest):
                 if index > 1000:
                     raise IOError("Tried too many filenames like: %s" % dest)
-                dest = os.path.join(path, "%s-%s.eml" % (filename, index))
+                dest = os.path.join(path, "%s_%s.eml" % (filename, index))
                 index = index + 1
             with open(dest, "w") as f:
                 f.write(data)


### PR DESCRIPTION
Using the hyphen "-" as the separator for filenames with collision has
makes these filenames sort earlier than the original file. It is
useful to be able to sort the generated files by their name and assume
that the last filename in the sorted list represents the latest sent
email.

Using an underscore solves this issue since it sorts later than a
period, e.g.

``` python
  >>> sorted(['2013-07-22-131955.eml', '2013-07-22-131955_1.eml', '2013-07-22-131955-1.eml'])
  ['2013-07-22-131955-1.eml', '2013-07-22-131955.eml', '2013-07-22-131955_1.eml']
```
