### PR TITLE
Add args and kwargs in DebuggingServer init method

### DIFF
--- a/mr/hermes/__init__.py
+++ b/mr/hermes/__init__.py
@@ -5,7 +5,7 @@ import time
 
 
 class DebuggingServer(smtpd.DebuggingServer):
-    def __init__(self, localaddr, remoteaddr):
+    def __init__(self, localaddr, remoteaddr, *args, **kwargs):
         self.path = os.environ.get('DEBUG_SMTP_OUTPUT_PATH')
         if self.path is None:
             print >>sys.stderr, "DEBUG_SMTP_OUTPUT_PATH not set, dumping mails to stdout only."

--- a/mr/hermes/__init__.py
+++ b/mr/hermes/__init__.py
@@ -9,7 +9,8 @@ class DebuggingServer(smtpd.DebuggingServer):
         self.path = os.environ.get('DEBUG_SMTP_OUTPUT_PATH')
         if self.path is None:
             print >>sys.stderr, "DEBUG_SMTP_OUTPUT_PATH not set, dumping mails to stdout only."
-        smtpd.DebuggingServer.__init__(self, localaddr, remoteaddr)
+        smtpd.DebuggingServer.__init__(
+            self, localaddr, remoteaddr, *args, **kwargs)
 
     def process_message(self, peer, mailfrom, rcpttos, data):
         smtpd.DebuggingServer.process_message(self, peer, mailfrom, rcpttos, data)


### PR DESCRIPTION
There are a couple more parameters other than the ones the DebuggingServer is
taking right now. We are ignoring them, but still, smtpd is passing them.

To accept them without questioning, I added the *args and **kwargs in the
constructor definition.

A more reliable, but less flexible solution could be to put there the named
arguments of the SMTPServer with the default values that are shown in the
documentation [here](https://docs.python.org/3/library/smtpd.html#smtpd.SMTPServer).

But it's much easier to be unaligned with the python library, _for example the
decode_data argument will have False as default from 3.6_.
